### PR TITLE
Handle relative paths

### DIFF
--- a/src/bo4e_generator/__main__.py
+++ b/src/bo4e_generator/__main__.py
@@ -9,10 +9,22 @@ from bo4e_generator.parser import create_init_files, generate_bo4e_schema
 from bo4e_generator.schema import get_namespace
 
 
+def resolve_paths(input_directory: Path, output_directory: Path) -> tuple[Path, Path]:
+    """
+    Resolve the input and output paths. The data-model-parser have problems with handling relative paths.
+    """
+    if not input_directory.is_absolute():
+        input_directory = input_directory.resolve()
+    if not output_directory.is_absolute():
+        output_directory = output_directory.resolve()
+    return input_directory, output_directory
+
+
 def generate_bo4e_schemas(input_directory: Path, output_directory: Path):
     """
     Generate all BO4E schemas from the given input directory and save them in the given output directory.
     """
+    input_directory, output_directory = resolve_paths(input_directory, output_directory)
     namespace = get_namespace(input_directory, output_directory)
     for schema_metadata in namespace.values():
         result = generate_bo4e_schema(schema_metadata, namespace)

--- a/unittests/test_main.py
+++ b/unittests/test_main.py
@@ -35,7 +35,8 @@ class TestMain:
         assert "typ" in Angebot.model_fields
 
     def test_single(self):
-        namespace = get_namespace(INPUT_DIR, OUTPUT_DIR)
+        os.chdir(BASE_DIR)
+        namespace = get_namespace(INPUT_DIR.resolve(), OUTPUT_DIR.resolve())
         schema_metadata = namespace["Angebot"]
         result = generate_bo4e_schema(schema_metadata, namespace)
 

--- a/unittests/test_main.py
+++ b/unittests/test_main.py
@@ -1,4 +1,6 @@
+import os
 from pathlib import Path
+from traceback import format_tb
 
 from click.testing import CliRunner
 from pydantic import BaseModel
@@ -7,16 +9,20 @@ from bo4e_generator.__main__ import main
 from bo4e_generator.parser import generate_bo4e_schema
 from bo4e_generator.schema import get_namespace
 
-OUTPUT_DIR = Path(__file__).parent / "output/bo4e"
-INPUT_DIR = Path(__file__).parent / "test_data/bo4e_schemas"
+BASE_DIR = Path(__file__).parents[1]
+OUTPUT_DIR = Path("unittests/output/bo4e")
+INPUT_DIR = Path("unittests/test_data/bo4e_schemas")
 
 
 class TestMain:
     def test_main(self):
+        os.chdir(BASE_DIR)
         runner = CliRunner()
         result = runner.invoke(main, ["--input-dir", str(INPUT_DIR), "--output-dir", str(OUTPUT_DIR)])
-        # generate_bo4e_schemas(input_directory=INPUT_DIR, output_directory=OUTPUT_DIR)
-        assert result.exit_code == 0, f"Error: {result.output}"
+
+        assert (
+            result.exit_code == 0
+        ), f"{result.exc_info[0].__name__}: {result.exc_info[1]}\n{''.join(format_tb(result.exc_info[2]))}"
         assert (OUTPUT_DIR / "bo" / "angebot.py").exists()
         assert (OUTPUT_DIR / "bo" / "preisblatt_netznutzung.py").exists()
         assert (OUTPUT_DIR / "com" / "com.py").exists()


### PR DESCRIPTION
Somehow the datamodel-code-generator has problems with relative paths (the way I use the tool).