### PR TITLE
Add argument to optionally define the BO4E-version

### DIFF
--- a/src/bo4e_generator/__main__.py
+++ b/src/bo4e_generator/__main__.py
@@ -86,7 +86,7 @@ def generate_bo4e_schemas(
     "-t",
     help="Optionally set the target BO4E version. If not defined, it tries to read it from `_version`. "
     "If it can't be found, it will be set to 'unknown'.",
-    type=Optional[str],
+    type=str,
     default=None,
 )
 @click.version_option(package_name="BO4E-Python-Generator")

--- a/src/bo4e_generator/__main__.py
+++ b/src/bo4e_generator/__main__.py
@@ -3,6 +3,7 @@ This module is the entry point for the CLI bo4e-generator.
 """
 import shutil
 from pathlib import Path
+from typing import Optional
 
 import click
 
@@ -22,7 +23,11 @@ def resolve_paths(input_directory: Path, output_directory: Path) -> tuple[Path, 
 
 
 def generate_bo4e_schemas(
-    input_directory: Path, output_directory: Path, pydantic_v1: bool = False, clear_output: bool = False
+    input_directory: Path,
+    output_directory: Path,
+    pydantic_v1: bool = False,
+    clear_output: bool = False,
+    target_version: Optional[str] = None,
 ):
     """
     Generate all BO4E schemas from the given input directory and save them in the given output directory.
@@ -30,7 +35,7 @@ def generate_bo4e_schemas(
     input_directory, output_directory = resolve_paths(input_directory, output_directory)
     namespace = get_namespace(input_directory)
     file_contents = parse_bo4e_schemas(input_directory, namespace, pydantic_v1)
-    version = get_version(namespace)
+    version = get_version(target_version, namespace)
     file_contents[Path("__version__.py")] = bo4e_version_file_content(version)
     file_contents[Path("__init__.py")] = bo4e_init_file_content(namespace, version)
     if clear_output and output_directory.exists():
@@ -76,12 +81,22 @@ def generate_bo4e_schemas(
     is_flag=True,
     default=False,
 )
+@click.option(
+    "--target-version",
+    "-t",
+    help="Optionally set the target BO4E version. If not defined, it tries to read it from `_version`. "
+    "If it can't be found, it will be set to 'unknown'.",
+    type=Optional[str],
+    default=None,
+)
 @click.version_option(package_name="BO4E-Python-Generator")
-def main(input_dir: Path, output_dir: Path, pydantic_v1: bool, clear_output: bool):
+def main(
+    input_dir: Path, output_dir: Path, pydantic_v1: bool, clear_output: bool, target_version: Optional[str] = None
+):
     """
     CLI entry point for the bo4e-generator.
     """
-    generate_bo4e_schemas(input_dir, output_dir, pydantic_v1, clear_output)
+    generate_bo4e_schemas(input_dir, output_dir, pydantic_v1, clear_output, target_version)
 
 
 if __name__ == "__main__":

--- a/src/bo4e_generator/schema.py
+++ b/src/bo4e_generator/schema.py
@@ -75,9 +75,9 @@ def get_version(target_version: Optional[str], namespace: dict[str, SchemaMetada
     Get the version of the bo4e schemas.
     """
     if target_version is not None:
-        gh_version_regex = re.compile(r"^v((?:\d+\.)*\d+)(?:-(rc\d+))?$")
+        gh_version_regex = re.compile(r"^v(?P<version>(?:\d+\.)*\d+)(?:-(?P<release_candidate>rc\d+))?$")
         if gh_version_regex.match(target_version) is not None:
-            target_version = gh_version_regex.sub(r"\1\2", target_version)
+            target_version = gh_version_regex.sub(r"\g<version>\g<release_candidate>", target_version)
         return target_version
     # The chosen class is arbitrary. All bo's and com's should contain the same version information.
     try:

--- a/src/bo4e_generator/schema.py
+++ b/src/bo4e_generator/schema.py
@@ -75,6 +75,9 @@ def get_version(target_version: Optional[str], namespace: dict[str, SchemaMetada
     Get the version of the bo4e schemas.
     """
     if target_version is not None:
+        GH_VERSION_REGEX = re.compile(r"^v((?:\d+\.)*\d+)(?:-(rc\d+))?$")
+        if GH_VERSION_REGEX.match(target_version) is not None:
+            target_version = GH_VERSION_REGEX.sub(r"\1\2", target_version)
         return target_version
     # The chosen class is arbitrary. All bo's and com's should contain the same version information.
     try:

--- a/src/bo4e_generator/schema.py
+++ b/src/bo4e_generator/schema.py
@@ -4,7 +4,7 @@ This module contains functionality to retrieve information about the schemas.
 import json
 import re
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
 
 from pydantic import BaseModel
 
@@ -70,10 +70,12 @@ def get_namespace(input_directory: Path) -> dict[str, SchemaMetadata]:
     return namespace
 
 
-def get_version(namespace: dict[str, SchemaMetadata]) -> str:
+def get_version(target_version: Optional[str], namespace: dict[str, SchemaMetadata]) -> str:
     """
     Get the version of the bo4e schemas.
     """
+    if target_version is not None:
+        return target_version
     # The chosen class is arbitrary. All bo's and com's should contain the same version information.
     try:
         return namespace["Angebot"].schema_parsed["properties"]["_version"]["default"]

--- a/src/bo4e_generator/schema.py
+++ b/src/bo4e_generator/schema.py
@@ -75,9 +75,9 @@ def get_version(target_version: Optional[str], namespace: dict[str, SchemaMetada
     Get the version of the bo4e schemas.
     """
     if target_version is not None:
-        GH_VERSION_REGEX = re.compile(r"^v((?:\d+\.)*\d+)(?:-(rc\d+))?$")
-        if GH_VERSION_REGEX.match(target_version) is not None:
-            target_version = GH_VERSION_REGEX.sub(r"\1\2", target_version)
+        gh_version_regex = re.compile(r"^v((?:\d+\.)*\d+)(?:-(rc\d+))?$")
+        if gh_version_regex.match(target_version) is not None:
+            target_version = gh_version_regex.sub(r"\1\2", target_version)
         return target_version
     # The chosen class is arbitrary. All bo's and com's should contain the same version information.
     try:

--- a/unittests/test_main.py
+++ b/unittests/test_main.py
@@ -17,7 +17,17 @@ class TestMain:
         os.chdir(BASE_DIR)
         runner = CliRunner()
         result = runner.invoke(
-            main, ["--input-dir", str(INPUT_DIR), "--output-dir", str(OUTPUT_DIR), "-p2", "--clear-output"]
+            main,
+            [
+                "--input-dir",
+                str(INPUT_DIR),
+                "--output-dir",
+                str(OUTPUT_DIR),
+                "-p2",
+                "--clear-output",
+                "-t",
+                "v0.6.1-rc13",
+            ],
         )
 
         assert (
@@ -37,4 +47,4 @@ class TestMain:
 
         from .output.bo4e import __version__  # type: ignore[import-not-found]
 
-        assert __version__ == "0.6.1rc13"
+        assert __version__ == "v0.6.1-rc13"

--- a/unittests/test_main.py
+++ b/unittests/test_main.py
@@ -47,4 +47,4 @@ class TestMain:
 
         from .output.bo4e import __version__  # type: ignore[import-not-found]
 
-        assert __version__ == "v0.6.1-rc13"
+        assert __version__ == "0.6.1rc13"


### PR DESCRIPTION
This version tag will be used for the module doc string of the bo4e package and for the `__version__` variable.