### PR TITLE
Use explicit default kwarg for better mypy

### DIFF
--- a/src/bo4e_generator/parser.py
+++ b/src/bo4e_generator/parser.py
@@ -190,7 +190,7 @@ def parse_bo4e_schemas(
         data_model_field_type=data_model_types.field_model,
         data_type_manager_type=data_model_types.data_type_manager,
         dump_resolve_reference_action=data_model_types.dump_resolve_reference_action,
-        use_annotated=not pydantic_v1,
+        # use_annotated=not pydantic_v1,
         use_double_quotes=True,
         use_schema_description=True,
         use_subclass_enum=True,
@@ -204,6 +204,7 @@ def parse_bo4e_schemas(
         remove_special_field_name_prefix=True,
         allow_extra_fields=False,
         allow_population_by_field_name=True,
+        use_default_kwarg=True,
     )
     parse_result = parser.parse()
     if not isinstance(parse_result, dict):


### PR DESCRIPTION
Apparently, mypy has big difficulties if the default value is somewhere in the `Annotated` arguments. Therefore, we will omit this feature.
Additionally, defining the default-value explicitly as kwarg-argument makes it easier for mypy to type check it correctly.